### PR TITLE
fix: install abseil script

### DIFF
--- a/scripts/install_abseil.sh
+++ b/scripts/install_abseil.sh
@@ -17,6 +17,10 @@
 set -o errexit
 set -o verbose
 
+sudo apt-get install -y stow ninja-build
+
+cd /tmp
+rm -rf abseil-cpp
 git clone https://github.com/abseil/abseil-cpp.git
 cd abseil-cpp
 git checkout d902eb869bcfacc1bad14933ed9af4bed006d481


### PR DESCRIPTION
This pull request includes a change to the `scripts/install_abseil.sh` file to enhance the installation process for Abseil. The most important change is the addition of commands to install necessary dependencies before cloning the Abseil repository.

Installation process improvements:

* [`scripts/install_abseil.sh`](diffhunk://#diff-71aa3b3e358a5e71c1d90bbbf14dfa7d2bf155bed43447072c1741c6ef037a19R20-R23): Added commands to install `stow` and `ninja-build` packages, and to remove any existing `abseil-cpp` directory before cloning the repository.