### PR TITLE
refactor: update LuaParameterDictionary reference count

### DIFF
--- a/cartographer/common/lua_parameter_dictionary.h
+++ b/cartographer/common/lua_parameter_dictionary.h
@@ -41,6 +41,10 @@ class FileResolver {
 // A parameter dictionary that gets loaded from Lua code.
 class LuaParameterDictionary {
  public:
+  enum class ReferenceCount { YES, NO };
+  LuaParameterDictionary(const std::string& code,
+                         ReferenceCount reference_count,
+                         std::unique_ptr<FileResolver> file_resolver);
   // Constructs the dictionary from a Lua Table specification.
   LuaParameterDictionary(const std::string& code,
                          std::unique_ptr<FileResolver> file_resolver);
@@ -80,10 +84,7 @@ class LuaParameterDictionary {
   GetArrayValuesAsDictionaries();
 
  private:
-  enum class ReferenceCount { YES, NO };
-  LuaParameterDictionary(const std::string& code,
-                         ReferenceCount reference_count,
-                         std::unique_ptr<FileResolver> file_resolver);
+
 
   // For GetDictionary().
   LuaParameterDictionary(lua_State* L, ReferenceCount reference_count,

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@
 
 <package format="3">
   <name>cartographer</name>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <description>
     Cartographer is a system that provides real-time simultaneous localization
     and mapping (SLAM) in 2D and 3D across multiple platforms and sensor


### PR DESCRIPTION
This pull request includes changes to the `cartographer/common/lua_parameter_dictionary.h` file to refactor the `LuaParameterDictionary` class. The main changes involve modifying the constructor and the `ReferenceCount` enum.

It allows to use a LuaParameterDictionary with the reference count disabled. This way we disable the following behaviours:
- If true will check that all keys were used on destruction.
- If true it will  verify that all parameters are read exactly once.

The reason to disable it is because we want to access / read the parameters from different components more than once.

Constructor and Enum Refactor:

* [`cartographer/common/lua_parameter_dictionary.h`](diffhunk://#diff-b6fc3ba62fae3a036ee1ce4a2e85ed0e540cb4e846e8e9cdcdbdef8da131ec62R44-R47): Moved the `ReferenceCount` enum from private to public scope and added a new constructor for `LuaParameterDictionary` that includes the `ReferenceCount` parameter.
* [`cartographer/common/lua_parameter_dictionary.h`](diffhunk://#diff-b6fc3ba62fae3a036ee1ce4a2e85ed0e540cb4e846e8e9cdcdbdef8da131ec62L83-R87): Removed the old constructor and the `ReferenceCount` enum from the private section of the `LuaParameterDictionary` class.